### PR TITLE
Add load method for named test inputs

### DIFF
--- a/test/src/load_module.cpp
+++ b/test/src/load_module.cpp
@@ -4,18 +4,16 @@
 
 #include <iostream>
 
-#define INPUT(fn) INPUT_DIR #fn ".bc"
-
 using namespace jitcall::test;
 
 TEST_CASE("Can load IR files into test cases") {
   SECTION("Empty IR file") {
-    auto mod = loadModule(INPUT(empty));
+    auto mod = loadNamedInput("empty");
     REQUIRE(mod);
   }
 
   SECTION("Non-empty bitcode file") {
-    auto mod = loadModule(INPUT(yneg));
+    auto mod = loadNamedInput("yneg");
     REQUIRE(mod);
     REQUIRE(mod->getFunction("func"));
   }

--- a/test/src/util.cpp
+++ b/test/src/util.cpp
@@ -18,5 +18,9 @@ std::unique_ptr<Module> loadModule(std::string const &path) {
   return parseIRFile(path, err, ctx);
 }
 
+std::unique_ptr<Module> loadNamedInput(std::string const &name) {
+  return loadModule(INPUT_DIR + name + ".bc");
+}
+
 } // namespace test
 } // namespace jitcall

--- a/test/src/util.h
+++ b/test/src/util.h
@@ -9,5 +9,7 @@ namespace test {
 
 std::unique_ptr<llvm::Module> loadModule(std::string const &path);
 
+std::unique_ptr<llvm::Module> loadNamedInput(std::string const &name);
+
 } // namespace test
 } // namespace jitcall


### PR DESCRIPTION
This just constructs the correct resource path and extension, then
delegates to the generic module loader.